### PR TITLE
Fix npm install

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,8 @@ var BASE = 'https://github.com/github/hub/releases/download/v' + VERSION + '/';
 module.exports = new BinWrapper()
 	.src(BASE + 'hub-linux-386-' + VERSION + '.tgz', 'linux', '386')
 	.src(BASE + 'hub-linux-amd64-' + VERSION + '.tgz', 'linux', 'amd64')
-	.src(BASE + 'hub-mac-amd64-' + VERSION + '.tgz', 'darwin')
-	.src(BASE + 'hub-windows-386-' + VERSION + '.tgz', 'windows', '386')
-	.src(BASE + 'hub-windows-amd64-' + VERSION + '.tgz', 'windows', 'amd64')
+	.src(BASE + 'hub-darwin-amd64-' + VERSION + '.tgz', 'darwin')
+	.src(BASE + 'hub-windows-386-' + VERSION + '.zip', 'windows', '386')
+	.src(BASE + 'hub-windows-amd64-' + VERSION + '.zip', 'windows', 'amd64')
 	.dest(path.join(__dirname, '../vendor'))
-	.use('hub');
+	.use('bin/hub');

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 var path = require('path');
 var BinWrapper = require('bin-wrapper');
 
-var VERSION = '2.2.1';
+var VERSION = '2.5.1';
 var BASE = 'https://github.com/github/hub/releases/download/v' + VERSION + '/';
 
 module.exports = new BinWrapper()

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,10 @@ var VERSION = '2.5.1';
 var BASE = 'https://github.com/github/hub/releases/download/v' + VERSION + '/';
 
 module.exports = new BinWrapper()
-	.src(BASE + 'hub-linux-386-' + VERSION + '.tar.gz', 'linux', '386')
-	.src(BASE + 'hub-linux-amd64-' + VERSION + '.tar.gz', 'linux', 'amd64')
-	.src(BASE + 'hub-mac-amd64-' + VERSION + '.tar.gz', 'darwin')
-	.src(BASE + 'hub-windows-386-' + VERSION + '.tar.gz', 'windows', '386')
-	.src(BASE + 'hub-windows-amd64-' + VERSION + '.tar.gz', 'windows', 'amd64')
+	.src(BASE + 'hub-linux-386-' + VERSION + '.tgz', 'linux', '386')
+	.src(BASE + 'hub-linux-amd64-' + VERSION + '.tgz', 'linux', 'amd64')
+	.src(BASE + 'hub-mac-amd64-' + VERSION + '.tgz', 'darwin')
+	.src(BASE + 'hub-windows-386-' + VERSION + '.tgz', 'windows', '386')
+	.src(BASE + 'hub-windows-amd64-' + VERSION + '.tgz', 'windows', 'amd64')
 	.dest(path.join(__dirname, '../vendor'))
 	.use('hub');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postinstall": "node lib/install.js"
   },
   "files": [
+    "lib",
     "index.js",
     "cli.js"
   ],


### PR DESCRIPTION
Hi!

I went to use this package and the install was failing because the `lib` folder was not being included in the npm package. I added it and updated the version of hub to the latest. If wanted I could also go in and update the code to latest js features (let/const, template literals, ect)

Cheers!